### PR TITLE
Add check for new email

### DIFF
--- a/cypress/plugins/email-account.js
+++ b/cypress/plugins/email-account.js
@@ -9,6 +9,7 @@ const simpleParser = require('mailparser').simpleParser
 const makeEmailAccount = async () => {
   // Generate a new Ethereal email inbox account
   const testAccount = await nodemailer.createTestAccount()
+  let lastQtyCount = null
 
   const emailConfig = {
     imap: {
@@ -53,6 +54,10 @@ const makeEmailAccount = async () => {
           return null
         } else {
           console.log('there are %d messages', messages.length)
+
+          // Check if new email has arrived
+          if (messages.length === lastQtyCount) return false;
+
           // grab the last email
           const mail = await simpleParser(
             messages[messages.length - 1].parts[0].body,


### PR DESCRIPTION
This prevents when calling the task "getLastEmail", not actually retrieving the latest email in the inbox. So when using the "recurse" function, it will return false if the inbox has the same messages quantity as previously.