### PR TITLE
Use Sendgrid API key for basic authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,13 +12,13 @@ Read the blog post ["Full Testing of HTML Emails using SendGrid and Ethereal Acc
 
 ## Install and run
 
-This application uses Sendgrid to send emails, thus you need to configure an account and expose it via environment variables
+This application uses Sendgrid to send emails, thus you need to configure an account and expose it via environment variables. For authentication, you need to create an API key. When using Basic Authentication, your username will always be "apikey," and your password will be your API key.
 
 ```
 SENDGRID_HOST=smtp.sendgrid.net
 SENDGRID_PORT=465
-SENDGRID_USER=
-SENDGRID_PASSWORD=
+SENDGRID_USER=apikey
+SENDGRID_PASSWORD=<sendgrid-api-key>
 # the same as verified sender
 SENDGRID_FROM=
 ```


### PR DESCRIPTION
After running `as-a email npm start` using my Sendgrid username/password and running `npx cypress open` to run the test, I kept getting the following error:
```shell
Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client
    at new NodeError (node:internal/errors:371:5)
    at ServerResponse.setHeader (node:_http_outgoing:576:11)
    at NodeNextResponse.setHeader (/Users/ikosumi/dev/temp/cypress-ethereal-email-example/node_modules/next/dist/server/base-http/node.js:59:19)
    at DevServer.renderError (/Users/ikosumi/dev/temp/cypress-ethereal-email-example/node_modules/next/dist/server/base-server.js:1124:17)
    at DevServer.renderError (/Users/ikosumi/dev/temp/cypress-ethereal-email-example/node_modules/next/dist/server/next-server.js:506:22)
    at DevServer.run (/Users/ikosumi/dev/temp/cypress-ethereal-email-example/node_modules/next/dist/server/dev/next-dev-server.js:451:35)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
    at async DevServer.handleRequest (/Users/ikosumi/dev/temp/cypress-ethereal-email-example/node_modules/next/dist/server/base-server.js:298:20) {
  code: 'ERR_HTTP_HEADERS_SENT'
}
error - Error: Invalid login: 535 Authentication failed: Basic authentication is not allowed with 2FA enabled. To fix, see https://sendgrid.com/docs/for-developers/sending-email/authentication/#basic-authentication
```

After some researching, I found this announcement in the [Sendgrid documentation](https://docs.sendgrid.com/for-developers/sending-email/authentication#basic-authentication). 
![Screenshot 2022-03-30 at 16 22 43](https://user-images.githubusercontent.com/64077312/160858056-6ea4b430-060c-436d-b6b6-5334df3798c8.png)

Apparently, they are also [enforcing 2FA](https://docs.sendgrid.com/for-developers/sending-email/authentication#two-factor-authentication) in order to login. I tried to disable 2FA and was getting yet another authentication error.

As a result, the cypress test kept failing:
![Screenshot 2022-03-30 at 16 22 59](https://user-images.githubusercontent.com/64077312/160858176-b910ee0a-3705-44b2-a121-12cc57e53cac.png)

This PR includes the reference to the Sendgrid docs on how to use API keys instead of username/password to make the test work again. 

After using "apikey" as the username and the generated API key value as the password, the test is now passing again.
![Screenshot 2022-03-30 at 16 30 49](https://user-images.githubusercontent.com/64077312/160859656-54da62c1-7201-4ece-b477-c418040a6afd.png)

